### PR TITLE
API Lots of module integration and additional columns

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,2 +1,3 @@
 <?php
+
 define('SITEWIDE_CONTENT_REPORT', basename(dirname(__FILE__)));

--- a/_config/contentreview.yml
+++ b/_config/contentreview.yml
@@ -1,0 +1,8 @@
+---
+Name: sitewidecontentreview
+Only:
+  moduleexists: contentreview
+---
+SitewideContentReport:
+  extensions:
+    - SitewideContentReview

--- a/_config/subsites.yml
+++ b/_config/subsites.yml
@@ -1,0 +1,11 @@
+---
+Name: sitewidecontentsubsites
+Only:
+  moduleexists: subsites
+---
+SitewideContentReport:
+  extensions:
+    - SitewideContentSubsites
+GridFieldBasicContentReport:
+  extensions:
+    - SitewideContentSubsites

--- a/_config/taxonomy.yml
+++ b/_config/taxonomy.yml
@@ -1,0 +1,8 @@
+---
+Name: sitewidecontenttaxonomy
+Only:
+  moduleexists: taxonomy
+---
+SitewideContentReport:
+  extensions:
+    - SitewideContentTaxonomy

--- a/code/SitewideContentReport.php
+++ b/code/SitewideContentReport.php
@@ -10,7 +10,7 @@ class SitewideContentReport extends SS_Report
      */
     public function title()
     {
-        return _t("SitewideContentReport.Title", "Site-wide content report");
+        return _t('SitewideContentReport.Title', 'Site-wide content report');
     }
 
     /**
@@ -18,31 +18,31 @@ class SitewideContentReport extends SS_Report
      */
     public function description()
     {
-        return _t("SitewideContentReport.Description", "All pages and files across all Subsites");
+        return _t('SitewideContentReport.Description', 'All pages and files across all Subsites');
     }
 
     /**
      * Returns an array with 2 elements, one with a list of Page on the site (and all subsites if
-     * applicable) and another with files
+     * applicable) and another with files.
      *
      * @return array
      */
     public function sourceRecords()
     {
-        if (class_exists("Subsite") && Subsite::get()->count() > 0) {
+        if (class_exists('Subsite') && Subsite::get()->count() > 0) {
             $origMode = Versioned::get_reading_mode();
-            Versioned::set_reading_mode("Stage.Stage");
+            Versioned::set_reading_mode('Stage.Stage');
             $items = array(
-                "Pages" => Subsite::get_from_all_subsites("SiteTree"),
-                "Files" => Subsite::get_from_all_subsites("File"),
+                'Pages' => Subsite::get_from_all_subsites('SiteTree'),
+                'Files' => Subsite::get_from_all_subsites('File'),
             );
             Versioned::set_reading_mode($origMode);
 
             return $items;
         } else {
             return array(
-                "Pages" => Versioned::get_by_stage("SiteTree", "Stage"),
-                "Files" => File::get(),
+                'Pages' => Versioned::get_by_stage('SiteTree', 'Stage'),
+                'Files' => File::get(),
             );
         }
     }
@@ -54,44 +54,60 @@ class SitewideContentReport extends SS_Report
      *
      * @return array
      */
-    public function columns($itemType = "Pages")
+    public function columns($itemType = 'Pages')
     {
         $columns = array(
-            "Title"           => array(
-                "title" => _t("SitewideContentReport.Name", "Name"),
-                "link"  => true,
+            'Title' => array(
+                'title' => _t('SitewideContentReport.Name', 'Name'),
+                'link' => true,
             ),
-            "Created.Nice"    => _t("SitewideContentReport.Created", "Date created"),
-            "LastEdited.Nice" => _t("SitewideContentReport.LastEdited", "Date last edited"),
+            'Created' => array(
+                'title' => _t('SitewideContentReport.Created', 'Date created'),
+                'formatting' => function ($value, $item) {
+                    return $item->dbObject('Created')->Nice();
+                },
+            ),
+            'LastEdited' => array(
+                'title' => _t('SitewideContentReport.LastEdited', 'Date last edited'),
+                'formatting' => function ($value, $item) {
+                    return $item->dbObject('LastEdited')->Nice();
+                },
+            ),
         );
 
-        $mainSiteLabel = _t("SitewideContentReport.MainSite", "Main Site");
-        if ($itemType == "Pages") {
-            $columns["ClassName"] = _t("SitewideContentReport.PageType", "Page type");
-            $columns["StageState"] = array(
-                "title"      => _t("SitewideContentReport.Stage", "Stage"),
-                "formatting" => function ($value, $item) {
-                    return ($item->isPublished()) ? _t("SitewideContentReport.Published", "Published") : _t("SitewideContentReport.Draft", "Draft");
+        if ($itemType == 'Pages') {
+            // Page specific fields
+            $columns['ClassName'] = _t('SitewideContentReport.PageType', 'Page type');
+            $columns['StageState'] = array(
+                'title' => _t('SitewideContentReport.Stage', 'Stage'),
+                'formatting' => function ($value, $item) {
+                    // Stage only 
+                    if (!$item->getExistsOnLive()) {
+                        return _t('SitewideContentReport.Draft', 'Draft');
+                    }
+
+                    // Pending changes
+                    if ($item->getIsModifiedOnStage()) {
+                        return _t('SitewideContentReport.PublishedWithChanges', 'Published (with changes)');
+                    }
+
+                    // If on live and unmodified
+                    return _t('SitewideContentReport.Published', 'Published');
                 },
             );
-            $columns["URLSegment"] = _t("SitewideContentReport.URL", "URL");
+            $columns['RelativeLink'] = _t('SitewideContentReport.Link', 'Link');
+            $columns['MetaDescription'] = array(
+                'title' => _t('SitewideContentReport.MetaDescription', 'Description'),
+                'printonly' => true,
+            );
         } else {
-            $columns["FileType"] = _t("SitewideContentReport.FileType", "File type");
-            $columns["Size"] = _t("SitewideContentReport.Size", "Size");
-            $columns["Filename"] = _t("SitewideContentReport.Directory", "Directory");
-            $mainSiteLabel .= " " . _t("SitewideContentReport.AccessFromAllSubsites", "(accessible by all subsites)");
+            // File specific fields
+            $columns['FileType'] = _t('SitewideContentReport.FileType', 'File type');
+            $columns['Size'] = _t('SitewideContentReport.Size', 'Size');
+            $columns['Filename'] = _t('SitewideContentReport.Directory', 'Directory');
         }
 
-        if (class_exists("Subsite") && Subsite::get()->count() > 0) {
-            $columns["SubsiteName"] = array(
-                "title"      => _t("SitewideContentReport.Subsite", "Subsite"),
-                "formatting" => function ($value, $item) use ($mainSiteLabel) {
-                    $title = ($item->Subsite()->Title) ? $item->Subsite()->Title : $mainSiteLabel;
-
-                    return $title;
-                },
-            );
-        }
+        $this->extend('updateColumns', $itemType, $columns);
 
         return $columns;
     }
@@ -101,19 +117,19 @@ class SitewideContentReport extends SS_Report
      */
     public function getCMSFields()
     {
-        Requirements::javascript(SITEWIDE_CONTENT_REPORT . "/javascript/sitewidecontentreport.js");
+        Requirements::javascript(SITEWIDE_CONTENT_REPORT.'/javascript/sitewidecontentreport.js');
         $fields = parent::getCMSFields();
 
-        if (class_exists("Subsite")) {
+        if (class_exists('Subsite')) {
             $subsites = Subsite::all_sites()->map();
-            $fields->insertBefore(HeaderField::create("PagesTitle", _t("SitewideContentReport.Pages", "Pages"), 3), "Report-Pages");
-            $fields->insertBefore(DropdownField::create("AllSubsites", _t("SitewideContentReport.FilterBy", "Filter by:"), $subsites)
-                ->addExtraClass("subsite-filter no-change-track")
-                ->setEmptyString("All Subsites"), "Report-Pages");
+            $fields->insertBefore(HeaderField::create('PagesTitle', _t('SitewideContentReport.Pages', 'Pages'), 3), 'Report-Pages');
+            $fields->insertBefore(DropdownField::create('AllSubsites', _t('SitewideContentReport.FilterBy', 'Filter by:'), $subsites)
+                ->addExtraClass('subsite-filter no-change-track')
+                ->setEmptyString('All Subsites'), 'Report-Pages');
         }
 
-        $fields->push(HeaderField::create("FilesTitle", _t("SitewideContentReport.Files", "Files"), 3));
-        $fields->push($this->getReportField("Files"));
+        $fields->push(HeaderField::create('FilesTitle', _t('SitewideContentReport.Files', 'Files'), 3));
+        $fields->push($this->getReportField('Files'));
 
         return $fields;
     }
@@ -126,72 +142,92 @@ class SitewideContentReport extends SS_Report
      *
      * @return GridField
      */
-    public function getReportField($itemType = "Pages")
+    public function getReportField($itemType = 'Pages')
     {
-        $params = isset($_REQUEST["filters"]) ? $_REQUEST["filters"] : array();
+        $params = isset($_REQUEST['filters']) ? $_REQUEST['filters'] : array();
         $items = $this->sourceRecords($params, null, null);
 
-        $gridField = new GridFieldBasicContentReport("Report-" . $itemType, false, $items[$itemType]);
+        $gridField = new GridFieldBasicContentReport('Report-'.$itemType, false, $items[$itemType]);
 
         $gridFieldConfig = GridFieldConfig::create()->addComponents(
             new GridFieldToolbarHeader(),
             new GridFieldSortableHeader(),
             new GridFieldDataColumns(),
             new GridFieldPaginator(),
-            new GridFieldButtonRow("after"),
-            $printButton = new GridFieldPrintButton("buttons-after-left"),
-            $exportButton = new GridFieldExportButton("buttons-after-left")
+            new GridFieldButtonRow('after'),
+            $printButton = new GridFieldPrintButton('buttons-after-left'),
+            $exportButton = new GridFieldExportButton('buttons-after-left')
         );
 
         $gridField->setConfig($gridFieldConfig);
-        $columns = $gridField->getConfig()->getComponentByType("GridFieldDataColumns");
 
+        /* @var $columns GridFieldDataColumns */
+        $columns = $gridField->getConfig()->getComponentByType('GridFieldDataColumns');
 
+        $exportFields = array();
         $displayFields = array();
         $fieldCasting = array();
         $fieldFormatting = array();
+        $dataFields = array();
 
         // Parse the column information
         foreach ($this->columns($itemType) as $source => $info) {
             if (is_string($info)) {
-                $info = array("title" => $info);
+                $info = array('title' => $info);
             }
 
-            if (isset($info["formatting"])) {
-                $fieldFormatting[$source] = $info["formatting"];
+            if (isset($info['formatting'])) {
+                $fieldFormatting[$source] = $info['formatting'];
             }
-            if (isset($info["csvFormatting"])) {
-                $csvFieldFormatting[$source] = $info["csvFormatting"];
-            }
-            if (isset($info["casting"])) {
-                $fieldCasting[$source] = $info["casting"];
+            if (isset($info['casting'])) {
+                $fieldCasting[$source] = $info['casting'];
             }
 
-            if (isset($info["link"]) && $info["link"]) {
+            if (isset($info['link']) && $info['link']) {
                 $fieldFormatting[$source] = function ($value, &$item) {
                     if ($item instanceof Page) {
                         return sprintf(
                             "<a href='%s'>%s</a>",
-                            Controller::join_links(singleton("CMSPageEditController")->Link("show"), $item->ID),
+                            Controller::join_links(singleton('CMSPageEditController')->Link('show'), $item->ID),
                             $value
                         );
                     }
 
                     return sprintf(
                         "<a href='%s'>%s</a>",
-                        Controller::join_links(singleton("AssetAdmin")->Link("EditForm"), "field/File/item", $item->ID, "edit"),
+                        Controller::join_links(singleton('AssetAdmin')->Link('EditForm'), 'field/File/item', $item->ID, 'edit'),
                         $value
                     );
                 };
             }
 
-            $displayFields[$source] = isset($info["title"]) ? $info["title"] : $source;
+            // Set custom datasource
+            if (isset($info['datasource'])) {
+                $dataFields[$source] = $info['datasource'];
+            }
+
+            // Set field name for export
+            $fieldTitle = isset($info['title']) ? $info['title'] : $source;
+
+            // If not print-only, then add to display list
+            if (empty($info['printonly'])) {
+                $displayFields[$source] = $fieldTitle;
+            }
+
+            // Assume that all displayed fields are printed also
+            $exportFields[$source] = $fieldTitle;
         }
+        // Set custom evaluated columns
+        $gridField->addDataFields($dataFields);
+
+        // Set visible fields
         $columns->setDisplayFields($displayFields);
         $columns->setFieldCasting($fieldCasting);
         $columns->setFieldFormatting($fieldFormatting);
 
-        $printExportColumns = $this->getPrintExportColumns($gridField, $itemType, $columns);
+        // Get print columns, and merge with print-only columns
+        $printExportColumns = $this->getPrintExportColumns($gridField, $itemType, $exportFields);
+
         $printButton->setPrintColumns($printExportColumns);
         $exportButton->setExportColumns($printExportColumns);
 
@@ -202,97 +238,36 @@ class SitewideContentReport extends SS_Report
      * Returns the columns for the export and print functionality.
      *
      * @param GridField $gridField
-     * @param string $itemType (i.e 'Pages' or 'Files')
-     * @param GridFieldDataColumns $columns
+     * @param string    $itemType      (i.e 'Pages' or 'Files')
+     * @param array     $exportColumns
      *
-     * @return GridFieldDataColumns
+     * @return array
      */
-    public function getPrintExportColumns($gridField, $itemType = "Pages", $columns)
+    public function getPrintExportColumns($gridField, $itemType, $exportColumns)
     {
-        $displayColumns = $columns->getDisplayFields($gridField);
+        // Swap RelativeLink for AbsoluteLink for export
+        $exportColumns['AbsoluteLink'] = _t('SitewideContentReport.Link', 'Link');
+        unset($exportColumns['RelativeLink']);
 
-        unset($displayColumns["SubsiteName"]);
-        unset($displayColumns["StageState"]);
+        $this->extend('updatePrintExportColumns', $gridField, $itemType, $exportColumns);
 
-        $displayColumns["Subsite.Title"] = _t("SitewideContentReport.Subsite", "Subsite");
-
-        if ($itemType == "Pages") {
-            $displayColumns["isPublished"] = _t("SitewideContentReport.Stage", "Stage");
-        } else {
-            unset($displayColumns["Stage"]);
-            $displayColumns["Subsite.Title"] = _t("SitewideContentReport.Subsite", "Subsite");
-        }
-
-        if (!class_exists("Subsite")) {
-            unset($displayColumns["Subsite.Title"]);
-        }
-
-        $displayColumns["AbsoluteLink"] = _t("SitewideContentReport.Link", "Link");
-
-        unset($displayColumns["URL"]);
-        unset($displayColumns["URLSegment"]);
-
-        return $displayColumns;
+        return $exportColumns;
     }
 }
 
 class GridFieldBasicContentReport extends GridField
 {
     /**
-     * Get the value of a named field  on the given record. Use of this method ensures
-     * that any special rules around the data for this gridfield are followed.
-     */
-    public function getDataFieldValue($record, $fieldName)
-    {
-        // Custom callbacks
-        if (isset($this->customDataFields[$fieldName])) {
-            $callback = $this->customDataFields[$fieldName];
-
-            return $callback($record);
-        }
-
-        // Links
-        if ($fieldName == "Link") {
-            return $record->AbsoluteLink();
-        }
-
-        // URLSegments
-        if ($fieldName == "URL" || $fieldName == "URLSegment") {
-            return $record->RelativeLink();
-        }
-
-        // Default implementation
-        if ($record->hasMethod("relField")) {
-            $value = $record->relField($fieldName);
-            if ($fieldName == "isPublished") {
-                $value = ($value) ? _t("SitewideContentReport.Published", "Published") : _t("SitewideContentReport.Draft", "Draft");
-            } elseif ($fieldName == "Subsite.Title") {
-                $value = ($value) ? $value : _t("SitewideContentReport.MainSite", "Main Site");
-            }
-            return $value;
-        } elseif ($record->hasMethod($fieldName)) {
-            return $record->$fieldName();
-        } else {
-            return $record->$fieldName;
-        }
-    }
-
-    /**
-     * @param int $total
-     * @param int $index
+     * @param int        $total
+     * @param int        $index
      * @param DataObject $record
      *
      * @return array
      */
     protected function getRowAttributes($total, $index, $record)
     {
-        $rowClasses = $this->newRowClasses($total, $index, $record);
-
-        return array(
-            "class"           => implode(" ", $rowClasses),
-            "data-id"         => $record->ID,
-            "data-class"      => $record->ClassName,
-            "data-subsite-id" => $record->SubsiteID,
-        );
+		$attributes = parent::getRowAttributes($total, $index, $record);
+		$this->extend('updateRowAttributes', $total, $index, $record, $attributes);
+		return $attributes;
     }
 }

--- a/code/extensions/SitewideContentReview.php
+++ b/code/extensions/SitewideContentReview.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Provides contentreview integration for sitewide content report.
+ *
+ * Requires https://github.com/silverstripe/silverstripe-contentreview
+ */
+class SitewideContentReview extends Extension
+{
+    /**
+     * Update columns to include subsite details.
+     *
+     * @param string $itemType (i.e 'Pages' or 'Files')
+     * @param array  $columns  Columns
+     */
+    public function updateColumns($itemType, &$columns)
+    {
+        if ($itemType !== 'Pages') {
+            return;
+        }
+
+        // {@see SiteTreeContentReview::getOwnerNames()}
+        $columns['OwnerNames'] = array(
+            'printonly' => true, // Hide on page report
+            'title' => _t('SitewideContentReport.Reviewer', 'Reviewer'),
+        );
+
+        // {@see SiteTreeContentView::getReviewDate()}
+        $columns['ReviewDate'] = array(
+            'printonly' => true, // Hide on page report
+            'title' => _t('SitewideContentReport.ReviewDate', 'Review Date'),
+            'formatting' => function ($value, $record) {
+                if ($val = $record->getReviewDate()) {
+                    return $val->Nice();
+                }
+            },
+        );
+    }
+}

--- a/code/extensions/SitewideContentSubsites.php
+++ b/code/extensions/SitewideContentSubsites.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Provides subsite integration for sitewide content report.
+ *
+ * Requires https://github.com/silverstripe/silverstripe-subsites
+ */
+class SitewideContentSubsites extends Extension
+{
+    /**
+     * Update columns to include subsite details.
+     *
+     * @param string $itemType (i.e 'Pages' or 'Files')
+     * @param array  $columns  Columns
+     */
+    public function updateColumns($itemType, &$columns)
+    {
+        // Skip single subsite setups
+        if (!Subsite::get()->count()) {
+            return;
+        }
+
+        // Set title
+        $mainSiteLabel = _t('SitewideContentReport.MainSite', 'Main Site');
+        if ($itemType !== 'Pages') {
+            $mainSiteLabel .= ' '._t('SitewideContentReport.AccessFromAllSubsites', '(accessible by all subsites)');
+        }
+
+        // Add subsite name
+        $columns['SubsiteName'] = array(
+            'title' => _t('SitewideContentReport.Subsite', 'Subsite'),
+            'datasource' => function ($item) use ($mainSiteLabel) {
+                $subsite = $item->Subsite();
+                if ($subsite && $subsite->exists() && $subsite->Title) {
+                    return $subsite->Title;
+                } else {
+                    return $mainSiteLabel;
+                }
+            },
+        );
+    }
+
+	public function updateRowAttributes($total, $index, $record, &$attributes) {
+		$attributes['data-subsite-id'] = $record->SubsiteID;
+	}
+}

--- a/code/extensions/SitewideContentTaxonomy.php
+++ b/code/extensions/SitewideContentTaxonomy.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * Provides taxonomy integration for sitewide content report.
+ *
+ * Requires https://github.com/silverstripe-labs/silverstripe-taxonomy
+ */
+class SitewideContentTaxonomy extends Extension
+{
+    /**
+     * Name of field to get tags from.
+     *
+     * @config
+     *
+     * @var string
+     */
+    private static $tag_field = 'Terms';
+
+    /**
+     * Update columns to include taxonomy details.
+     *
+     * @param string $itemType (i.e 'Pages' or 'Files')
+     * @param array  $columns  Columns
+     */
+    public function updateColumns($itemType, &$columns)
+    {
+        if ($itemType !== 'Pages') {
+            return;
+        }
+
+        // Check if pages has the tags field
+        if (!self::enabled()) {
+            return;
+        }
+
+        // Set column
+        $field = Config::inst()->get(__CLASS__, 'tag_field');
+        $columns['Terms'] = array(
+            'printonly' => true, // Hide on page report
+            'title' => _t('SitewideContentReport.Tags', 'Tags'),
+            'datasource' => function ($record) use ($field) {
+                $tags = $record->$field()->column('Name');
+
+                return implode(', ', $tags);
+            },
+        );
+    }
+
+    /**
+     * Check if this field is enabled.
+     *
+     * @return bool
+     */
+    public static function enabled()
+    {
+        if (!class_exists('TaxonomyTerm')) {
+            return false;
+        }
+
+        // Check if pages has the tags field
+        $field = Config::inst()->get(__CLASS__, 'tag_field');
+
+        return singleton('Page')->hasMethod($field);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,8 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^3.7",
+		"silverstripe/contentreview": "^2.1",
+		"silverstripe/taxonomy": "^1.1",
 		"silverstripe/subsites": "^1.0"
 	},
 	"authors": [

--- a/docs/en/developer-documentation.md
+++ b/docs/en/developer-documentation.md
@@ -1,0 +1,49 @@
+# Developer Documentation
+
+## Customising the output columns
+
+In order to customise the columns included in a report you can build a custom extension and apply it to the 
+SitewideContentReport as necessary.
+
+The build in extensions, for instance, each add custom columns extracted from other modules, and can
+be used as a base for developing further extensions:
+
+ - `SitewideContentReview` - Integrates with the [content review](https://github.com/silverstripe/silverstripe-contentreview) module.
+ - `SitewideContentSubsites` - Integrates with the [subsites](https://github.com/silverstripe/silverstripe-subsites) module.
+ - `SitewideContentTaxonomy` - Integrates with the [taxonomy](https://github.com/silverstripe-labs/silverstripe-taxonomy) module.
+
+For instance, in order to add a new Page field to the report you could add an extension similar to the below:
+
+
+	::php
+	<?php
+
+	class MyReportExtension extends Extension {
+		public function updateColumns($itemType, &$columns) {
+			if(itemType !== 'Pages') {
+				return;
+			}
+			$columns["Price"] = array(
+				"title" => _t("SitewideContentReport.Subsite", "Subsite"),
+				"formatting" => function ($value, $item) use ($mainSiteLabel) {
+					return number_format($value, 2, '.', ',');
+				},
+			);
+		}
+	}
+
+
+The $columns array can have any number of items added, where the key of the array represents the
+field name to be included.
+
+Each item can be either a literal string (which will be used as the title), or an array that may contain
+the following key => value pairs:
+
+ * `title`: The title to use for the column header
+ * `format`: A method callback which will take the raw value and original object, and return a formatted
+    string.
+ * `datasource`: If the value for this column isn't a direct field on the original object, a custom callback
+   can be set here. Unlike `format` this callback will only take a single parameter, the original object.
+ * `printonly`: Set to true if this column is only visible on the print or export-to-csv views.
+ * `casting`: Specify a field type (e.g. `Text` or `Int`) in order to assist with field casting. This is not
+    necessary if `formatting` is used.

--- a/tests/SitewideContentReportTest.php
+++ b/tests/SitewideContentReportTest.php
@@ -8,10 +8,10 @@ class SitewideContentReportTest extends SapphireTest
     /**
      * @var string
      */
-    protected static $fixture_file = "SitewideContentReportTest.yml";
+    protected static $fixture_file = 'SitewideContentReportTest.yml';
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function setUp()
     {
@@ -19,7 +19,7 @@ class SitewideContentReportTest extends SapphireTest
 
         foreach (range(1, 5) as $i) {
             /** @var SiteTree $page */
-            $page = $this->objFromFixture("Page", "page{$i}");
+            $page = $this->objFromFixture('Page', "page{$i}");
 
             if ($i <= 3) {
                 $page->doPublish();
@@ -32,18 +32,18 @@ class SitewideContentReportTest extends SapphireTest
         $report = SitewideContentReport::create();
         $records = $report->sourceRecords();
 
-        $this->assertEquals(count($records), 2, "Returns an array with 2 items, one for pages and one for files");
-        $this->assertArrayHasKey("Pages", $records);
-        $this->assertArrayHasKey("Files", $records);
+        $this->assertEquals(count($records), 2, 'Returns an array with 2 items, one for pages and one for files');
+        $this->assertArrayHasKey('Pages', $records);
+        $this->assertArrayHasKey('Files', $records);
 
         /** @var DataList $pages */
-        $pages = $records["Pages"];
+        $pages = $records['Pages'];
 
         /** @var DataList $files */
-        $files = $records["Files"];
+        $files = $records['Files'];
 
-        $this->assertEquals($pages->count(), 5, "Total number of pages");
-        $this->assertEquals($files->count(), 1, "Total number of files");
+        $this->assertEquals($pages->count(), 5, 'Total number of pages');
+        $this->assertEquals($files->count(), 1, 'Total number of files');
     }
 
     public function testGetCMSFields()
@@ -51,15 +51,88 @@ class SitewideContentReportTest extends SapphireTest
         $report = SitewideContentReport::create();
         $fields = $report->getCMSFields();
 
-        if (class_exists("Subsite")) {
-            $field = $fields->fieldByName("AllSubsites");
-            $count = count(array_filter(array_keys($field->getSource()), function($value) {
+        if (class_exists('Subsite')) {
+            $field = $fields->fieldByName('AllSubsites');
+            $count = count(array_filter(array_keys($field->getSource()), function ($value) {
                 return is_int($value);
             }));
 
-            $this->assertEquals(4, $count, "2 subsites plus 2 added options to filter by subsite");
+            $this->assertEquals(4, $count, '2 subsites plus 2 added options to filter by subsite');
         } else {
-            $this->assertNull($fields->fieldByName("AllSubsites"));
+            $this->assertNull($fields->fieldByName('AllSubsites'));
+        }
+    }
+
+    public function testReportFields()
+    {
+        $report = SitewideContentReport::create();
+
+        // Test pages view
+        $gridField = $report->getReportField('Pages');
+
+        /* @var $columns GridFieldDataColumns */
+        $columns = $gridField->getConfig()->getComponentByType('GridFieldDataColumns');
+        $displayed = $columns->getDisplayFields($gridField);
+
+        $this->assertArrayHasKey('Title', $displayed);
+        $this->assertArrayHasKey('Created', $displayed);
+        $this->assertArrayHasKey('LastEdited', $displayed);
+        $this->assertArrayHasKey('ClassName', $displayed);
+        $this->assertArrayHasKey('StageState', $displayed);
+
+        // Use correct link
+        $this->assertArrayHasKey('RelativeLink', $displayed);
+        $this->assertArrayNotHasKey('AbsoluteLink', $displayed);
+
+        if (class_exists('Subsite')) {
+            $this->assertArrayHasKey('SubsiteName', $displayed);
+        } else {
+            $this->assertArrayNotHasKey('SubsiteName', $displayed);
+        }
+
+        // Export-only fields are not in display list
+        $this->assertArrayNotHasKey('Terms', $displayed);
+        $this->assertArrayNotHasKey('OwnerNames', $displayed);
+        $this->assertArrayNotHasKey('ReviewDate', $displayed);
+        $this->assertArrayNotHasKey('MetaDescription', $displayed);
+
+        // Tests print / export field
+        /* @var $export GridFieldExportButton */
+        $export = $gridField->getConfig()->getComponentByType('GridFieldExportButton');
+        $exported = $export->getExportColumns();
+
+        // Make sure all shared columns are in this report
+        $this->assertArrayHasKey('Title', $exported);
+        $this->assertArrayHasKey('Created', $exported);
+        $this->assertArrayHasKey('LastEdited', $exported);
+        $this->assertArrayHasKey('ClassName', $exported);
+        $this->assertArrayHasKey('StageState', $exported);
+
+        // Export-only fields
+        $this->assertArrayHasKey('MetaDescription', $exported);
+
+        // Use correct link
+        $this->assertArrayHasKey('AbsoluteLink', $exported);
+        $this->assertArrayNotHasKey('RelativeLink', $exported);
+
+        if (class_exists('Subsite')) {
+            $this->assertArrayHasKey('SubsiteName', $exported);
+        } else {
+            $this->assertArrayNotHasKey('SubsiteName', $exported);
+        }
+
+        if (SitewideContentTaxonomy::enabled()) {
+            $this->assertArrayHasKey('Terms', $exported);
+        } else {
+            $this->assertArrayNotHasKey('Terms', $exported);
+        }
+
+        if (class_exists('SiteTreeContentReview')) {
+            $this->assertArrayHasKey('OwnerNames', $exported);
+            $this->assertArrayHasKey('ReviewDate', $exported);
+        } else {
+            $this->assertArrayNotHasKey('OwnerNames', $exported);
+            $this->assertArrayNotHasKey('ReviewDate', $exported);
         }
     }
 }


### PR DESCRIPTION
API Integration with contentreview module
API Integration with taxonomy module
API Add MetaDescription field
API Let date columns be sortable
API Stage now shows live / live with changes

I've moved a lot of customisation into module-specific extensions, and added 'datasource' as a new extensible alternative to lots of build-in custom code.

This pull WILL require a new major version increase as it's not backwards compatible.