### PR TITLE
FIX Site wide content report is no longer JavaScript controlled, exporting works

### DIFF
--- a/javascript/sitewidecontentreport.js
+++ b/javascript/sitewidecontentreport.js
@@ -1,3 +1,4 @@
+// Please note that this file is no longer used any more
 (function($) {
 	$.entwine('ss', function($) {
 

--- a/src/SitewideContentReport.php
+++ b/src/SitewideContentReport.php
@@ -2,30 +2,30 @@
 
 namespace SilverStripe\SiteWideContentReport;
 
-use SilverStripe\Forms\FieldList;
-use SilverStripe\Forms\GridField\GridField;
-use SilverStripe\Subsites\Model\Subsite;
 use Page;
-use SilverStripe\Versioned\Versioned;
-use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\AssetAdmin\Controller\AssetAdmin;
 use SilverStripe\Assets\File;
 use SilverStripe\Assets\Folder;
-use SilverStripe\View\Requirements;
-use SilverStripe\Forms\HeaderField;
-use SilverStripe\Forms\DropdownField;
-use SilverStripe\SiteWideContentReport\Form\GridFieldBasicContentReport;
-use SilverStripe\Forms\GridField\GridFieldConfig;
-use SilverStripe\Forms\GridField\GridFieldToolbarHeader;
-use SilverStripe\Forms\GridField\GridFieldSortableHeader;
-use SilverStripe\Forms\GridField\GridFieldDataColumns;
-use SilverStripe\Forms\GridField\GridFieldPaginator;
-use SilverStripe\Forms\GridField\GridFieldButtonRow;
-use SilverStripe\Forms\GridField\GridFieldPrintButton;
-use SilverStripe\Forms\GridField\GridFieldExportButton;
 use SilverStripe\CMS\Controllers\CMSPageEditController;
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Controller;
-use SilverStripe\AssetAdmin\Controller\AssetAdmin;
+use SilverStripe\Forms\DropdownField;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldButtonRow;
+use SilverStripe\Forms\GridField\GridFieldConfig;
+use SilverStripe\Forms\GridField\GridFieldDataColumns;
+use SilverStripe\Forms\GridField\GridFieldExportButton;
+use SilverStripe\Forms\GridField\GridFieldPaginator;
+use SilverStripe\Forms\GridField\GridFieldPrintButton;
+use SilverStripe\Forms\GridField\GridFieldSortableHeader;
+use SilverStripe\Forms\GridField\GridFieldToolbarHeader;
+use SilverStripe\Forms\HeaderField;
 use SilverStripe\Reports\Report;
+use SilverStripe\SiteWideContentReport\Form\GridFieldBasicContentReport;
+use SilverStripe\Subsites\Model\Subsite;
+use SilverStripe\Versioned\Versioned;
+use SilverStripe\View\Requirements;
 
 /**
  * Content side-report listing all pages and files from all sub sites.
@@ -59,9 +59,10 @@ class SitewideContentReport extends Report
      * Returns an array with 2 elements, one with a list of Page on the site (and all subsites if
      * applicable) and another with files.
      *
+     * @param array $params
      * @return array
      */
-    public function sourceRecords()
+    public function sourceRecords($params)
     {
         if (class_exists(Subsite::class) && Subsite::get()->count() > 0) {
             $origMode = Versioned::get_reading_mode();
@@ -70,15 +71,20 @@ class SitewideContentReport extends Report
                 'Pages' => Subsite::get_from_all_subsites(SiteTree::class),
                 'Files' => Subsite::get_from_all_subsites(File::class),
             ];
+
+            if (array_key_exists('AllSubsites', $params)) {
+                $items['Pages'] = $items['Pages']->filter(['SubsiteID' => $params['AllSubsites']]);
+                $items['Files'] = $items['Files']->filter(['SubsiteID' => [0, $params['AllSubsites']]]);
+            }
             Versioned::set_reading_mode($origMode);
 
             return $items;
-        } else {
-            return [
-                'Pages' => Versioned::get_by_stage(SiteTree::class, 'Stage'),
-                'Files' => File::get(),
-            ];
         }
+
+        return [
+            'Pages' => Versioned::get_by_stage(SiteTree::class, 'Stage'),
+            'Files' => File::get(),
+        ];
     }
 
     public function getCount($params = array())
@@ -115,7 +121,7 @@ class SitewideContentReport extends Report
             ],
         ];
 
-        if ($itemType == 'Pages') {
+        if ($itemType === 'Pages') {
             // Page specific fields
             $columns['i18n_singular_name'] = _t(__CLASS__ . '.PageType', 'Page type');
             $columns['StageState'] = [
@@ -167,27 +173,11 @@ class SitewideContentReport extends Report
      */
     public function getCMSFields()
     {
-        Requirements::javascript('silverstripe/sitewidecontent-report: javascript/sitewidecontentreport.js');
         Requirements::css('silverstripe/sitewidecontent-report: css/sitewidecontentreport.css');
         $fields = parent::getCMSFields();
 
-        if (class_exists(Subsite::class)) {
-            $subsites = Subsite::all_sites()->map();
-            $fields->insertBefore(
-                HeaderField::create('PagesTitle', _t(__CLASS__ . '.Pages', 'Pages'), 3),
-                'Report-Pages'
-            );
-            $fields->insertBefore(
-                DropdownField::create('AllSubsites', _t(__CLASS__ . '.FilterBy', 'Filter by:'), $subsites)
-                    ->addExtraClass('subsite-filter no-change-track')
-                    ->setEmptyString('All Subsites'),
-                'Report-Pages'
-            );
-        }
-
         $fields->push(HeaderField::create('FilesTitle', _t(__CLASS__ . '.Files', 'Files'), 3));
         $fields->push($this->getReportField('Files'));
-
 
         return $fields;
     }
@@ -316,5 +306,25 @@ class SitewideContentReport extends Report
         $this->extend('updatePrintExportColumns', $gridField, $itemType, $exportColumns);
 
         return $exportColumns;
+    }
+
+    public function parameterFields()
+    {
+        if (!class_exists(Subsite::class)) {
+            return null;
+        }
+
+        $subsites = Subsite::all_sites()->map()->toArray();
+        // Pad the 0 a little so doesn't get treated as the empty string and remove the original
+        $mainSite = ['000' => $subsites[0]];
+        unset($subsites[0]);
+        $subsites = $mainSite + $subsites;
+
+        $header = HeaderField::create('PagesTitle', _t(__CLASS__ . '.Pages', 'Pages'), 3);
+        $dropdown = DropdownField::create('AllSubsites', _t(__CLASS__ . '.FilterBy', 'Filter by:'), $subsites);
+        $dropdown->addExtraClass('subsite-filter no-change-track');
+        $dropdown->setEmptyString(_t(__CLASS__ . '.ALL_SUBSITES', 'All Subsites'));
+
+        return FieldList::create($header, $dropdown);
     }
 }

--- a/src/SitewideContentReport.php
+++ b/src/SitewideContentReport.php
@@ -62,7 +62,7 @@ class SitewideContentReport extends Report
      * @param array $params
      * @return array
      */
-    public function sourceRecords($params)
+    public function sourceRecords($params = [])
     {
         if (class_exists(Subsite::class) && Subsite::get()->count() > 0) {
             $origMode = Versioned::get_reading_mode();

--- a/src/SitewideContentReport.php
+++ b/src/SitewideContentReport.php
@@ -242,7 +242,7 @@ class SitewideContentReport extends Report
                     }
 
                     return sprintf(
-                        "<a href='%s'>%s</a>",
+                        '<a href="%s" target="_blank" rel="noopener">%s</a>',
                         Controller::join_links(
                             singleton(AssetAdmin::class)->Link('EditForm'),
                             'field/File/item',

--- a/tests/SitewideContentReportTest.php
+++ b/tests/SitewideContentReportTest.php
@@ -4,15 +4,17 @@ namespace SilverStripe\SiteWideContentReport\Tests;
 
 use Page;
 use SilverStripe\CMS\Model\SiteTree;
+use SilverStripe\ContentReview\Extensions\SiteTreeContentReview;
 use SilverStripe\Core\Config\Config;
-use SilverStripe\ORM\DataList;
-use SilverStripe\SiteWideContentReport\SitewideContentReport;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\DropdownField;
+use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\GridField\GridFieldDataColumns;
 use SilverStripe\Forms\GridField\GridFieldExportButton;
+use SilverStripe\ORM\DataList;
 use SilverStripe\SiteWideContentReport\Model\SitewideContentTaxonomy;
-use SilverStripe\Dev\SapphireTest;
+use SilverStripe\SiteWideContentReport\SitewideContentReport;
 use SilverStripe\Subsites\Model\Subsite;
-use SilverStripe\ContentReview\Extensions\SiteTreeContentReview;
 
 class SitewideContentReportTest extends SapphireTest
 {
@@ -48,7 +50,7 @@ class SitewideContentReportTest extends SapphireTest
     public function testSourceRecords()
     {
         $report = SitewideContentReport::create();
-        $records = $report->sourceRecords();
+        $records = $report->sourceRecords([]);
 
         $this->assertCount(2, $records, 'Returns an array with 2 items, one for pages and one for files');
         $this->assertArrayHasKey('Pages', $records);
@@ -64,18 +66,18 @@ class SitewideContentReportTest extends SapphireTest
         $this->assertCount(1, $files, 'Total number of files');
     }
 
-    public function testGetCMSFields()
+    public function testParameterFields()
     {
         $report = SitewideContentReport::create();
-        $fields = $report->getCMSFields();
+        /** @var FieldList $fields */
+        $fields = $report->parameterFields();
 
         if (class_exists(Subsite::class)) {
+            /** @var DropdownField $field */
             $field = $fields->fieldByName('AllSubsites');
-            $count = count(array_filter(array_keys($field->getSource()), function ($value) {
-                return is_int($value);
-            }));
+            $keys = array_filter(array_keys($field->getSource()));
 
-            $this->assertEquals(4, $count, '2 subsites plus 2 added options to filter by subsite');
+            $this->assertCount(4, $keys, '2 subsites plus 2 added options to filter by subsite');
         } else {
             $this->assertNull($fields->fieldByName('AllSubsites'));
         }


### PR DESCRIPTION
This means the report is no longer dynamically updated (by hiding and showing rows) with JavaScript, but rather uses the Report filtering API instead.

This fixes #36, where dynamically updated rows weren't being respected in CSV exports, and fixes #35 where the top border disappears when you do this too. Also fixes #31 and fixes #32.

The 000 hack is to prevent framework from treating a zero value as the empty string.