### PR TITLE
API Use updated report API, set PHP 7.4 as minimum version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,9 @@
         "reports"
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
-        "silverstripe/cms": "^4.0"
+        "php": "^7.4 || ^8.0",
+        "silverstripe/cms": "^4.0",
+        "silverstripe/reports": "^4.11"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/src/SitewideContentReport.php
+++ b/src/SitewideContentReport.php
@@ -88,7 +88,7 @@ class SitewideContentReport extends Report
         ];
     }
 
-    public function getCount($params = array())
+    public function getCount($params = [], $limit = null)
     {
         $records = $this->sourceRecords();
         return $records['Pages']->count() + $records['Files']->count();


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-framework/issues/10219
