### PR TITLE
MNT Use GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  # Every Saturday at 11:00am UTC
+  schedule:
+    - cron: '0 11 * * 6'
+
+jobs:
+  ci:
+    name: CI
+    # Only run cron on the silverstripe account
+    if: (github.event_name == 'schedule' && startsWith(github.repository, 'silverstripe/')) || (github.event_name != 'schedule')
+    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1

--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -1,0 +1,17 @@
+name: Keepalive
+
+on:
+  workflow_dispatch:
+  # The 4th of every month at 10:50am UTC
+  schedule:
+    - cron: '50 10 4 * *'
+
+jobs:
+  keepalive:
+    name: Keepalive
+    # Only run cron on the silverstripe account
+    if: (github.event_name == 'schedule' && startsWith(github.repository, 'silverstripe/')) || (github.event_name != 'schedule')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Keepalive
+        uses: silverstripe/gha-keepalive@v1

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,13 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "squizlabs/php_codesniffer": "^3.0"
+        "squizlabs/php_codesniffer": "^3.0",
+        "silverstripe/subsites": "^2",
+        "silverstripe/taxonomy": "^2",
+        "silverstripe/contentreview": "^4"
+    },
+    "conflict": {
+        "silverstripe/reports": ">=4.11.0"
     },
     "authors": [
         {

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Site-wide content Report
 
-[![Build Status](https://api.travis-ci.com/silverstripe/silverstripe-sitewidecontent-report.svg?branch=3)](https://travis-ci.com/silverstripe/silverstripe-sitewidecontent-report)
+[![CI](https://github.com/silverstripe/silverstripe-sitewidecontent-report/actions/workflows/ci.yml/badge.svg)](https://github.com/silverstripe/silverstripe-sitewidecontent-report/actions/workflows/ci.yml)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/silverstripe/silverstripe-sitewidecontent-report/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/silverstripe/silverstripe-sitewidecontent-report/?branch=master)
 [![codecov](https://codecov.io/gh/silverstripe/silverstripe-sitewidecontent-report/branch/master/graph/badge.svg)](https://codecov.io/gh/silverstripe/silverstripe-sitewidecontent-report)
 [![SilverStripe supported module](https://img.shields.io/badge/silverstripe-supported-0071C4.svg)](https://www.silverstripe.org/software/addons/silverstripe-commercially-supported-module-list/)


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/11

Workflow run https://github.com/creative-commoners/silverstripe-sitewidecontent-report/actions?query=branch%3Apulls%2F3.2%2Fmodule-standards

Change composer conflict to `<2.11.0` on merge-up to `3.3`