### PR TITLE
FIX update defensive check on tags field method

### DIFF
--- a/src/Model/SitewideContentTaxonomy.php
+++ b/src/Model/SitewideContentTaxonomy.php
@@ -48,9 +48,13 @@ class SitewideContentTaxonomy extends Extension
             'printonly' => true, // Hide on page report
             'title' => _t('SilverStripe\\SiteWideContentReport\\SitewideContentReport.Tags', 'Tags'),
             'datasource' => function ($record) use ($field) {
-                $tags = $record->$field()->column('Name');
+                if ($record->hasMethod($field)) {
+                    $tags = $record->$field()->column('Name');
 
-                return implode(', ', $tags);
+                    return implode(', ', $tags);
+                }
+
+                return '';
             },
         ];
     }


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->

If a page type is removed and the page type is orphaned. The report will fail when it is exported to CSV on this data object because it doesn't find the Terms() on SiteTree.

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

1. Delete a page type that is in use (Pages are currently assigned to it)
2. Generate report
3. Export report
4. The report should be generated and downloaded

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-sitewidecontent-report/issues/77

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
